### PR TITLE
fix customerForm instantiation in otherFormInTab Samples 

### DIFF
--- a/Serene/Serene.Web/Modules/BasicSamples/Dialogs/OtherFormInTab/OtherFormInTabDialog.ts
+++ b/Serene/Serene.Web/Modules/BasicSamples/Dialogs/OtherFormInTab/OtherFormInTabDialog.ts
@@ -24,7 +24,7 @@ namespace Serene.BasicSamples {
             });
 
             // this is just a helper to access editors if needed
-            this.customerForm = new Northwind.CustomerForm((this.customerPropertyGrid as any).idPrefix);
+            this.customerForm = new Northwind.CustomerForm((this.customerPropertyGrid as any).options.idPrefix);
 
             // initialize validator for customer form
             this.customerValidator = this.byId("CustomerForm").validate(Q.validateOptions({}));

--- a/Serene/Serene.Web/Modules/BasicSamples/Dialogs/OtherFormInTabOneBar/OtherFormOneBarDialog.ts
+++ b/Serene/Serene.Web/Modules/BasicSamples/Dialogs/OtherFormInTabOneBar/OtherFormOneBarDialog.ts
@@ -26,7 +26,7 @@ namespace Serene.BasicSamples {
             });
 
             // this is just a helper to access editors if needed
-            this.customerForm = new Northwind.CustomerForm((this.customerPropertyGrid as any).idPrefix);
+            this.customerForm = new Northwind.CustomerForm((this.customerPropertyGrid as any).options.idPrefix);
 
             // initialize validator for customer form
             this.customerValidator = this.byId("CustomerForm").validate(Q.validateOptions({}));


### PR DESCRIPTION
The 'idPrefix' property is located, in fact, under the 'options' property of the form object