### PR TITLE
[Bug] Authorization.hasPermission() vs. Q.Authorization.hasPermission()

### DIFF
--- a/Serene/Serene.Core/Modules/Administration/User/Authentication/Authorization.ts
+++ b/Serene/Serene.Core/Modules/Administration/User/Authentication/Authorization.ts
@@ -8,7 +8,6 @@
     });
 
     export function hasPermission(permissionKey: string) {
-        let ud = userDefinition;
-        return ud.Username === 'admin' || !!ud.Permissions[permissionKey];
+        return Q.Authorization.hasPermission(permissionKey);
     }
 }

--- a/Serene/Serene.Web/Modules/Administration/User/Authentication/Authorization.ts
+++ b/Serene/Serene.Web/Modules/Administration/User/Authentication/Authorization.ts
@@ -8,7 +8,6 @@
     });
 
     export function hasPermission(permissionKey: string) {
-        let ud = userDefinition;
-        return ud.Username === 'admin' || !!ud.Permissions[permissionKey];
+        return Q.Authorization.hasPermission(permissionKey);
     }
 }


### PR DESCRIPTION
Authorization.hasPermission() in Serene template is either obsolete or should call Q.Authorization.hasPermission()

I stumbled upon this while troubleshooting or'ed permission keys, i.e. 'Default:Read|Default:Write'. This is correctly implemented in  Q.Authorization.hasPermission(), but not in Authorization.hasPermission().