### PR TITLE
Fix connect failure: Azure Database for Postgresql

### DIFF
--- a/Serene/Serene.Core/Initialization/DataMigrations.cs
+++ b/Serene/Serene.Core/Initialization/DataMigrations.cs
@@ -110,7 +110,7 @@ namespace Serene
                 }
 
             var catalog = cb[catalogKey] as string;
-            cb[catalogKey] = null;
+            cb[catalogKey] = isPostgres ? "postgres" : null;
 
             using (var serverConnection = SqlConnections.New(cb.ConnectionString, cs.ProviderName, cs.Dialect))
             {


### PR DESCRIPTION
## Workaround
Npgsql <-> Azure DB for Postgresql

Npgsql doesn't appear to be able to handle not being passed a database, as part of connection string in Azure, where login name has the format login@name. 
You'd expect it to default to database postgres, but alas, it doesn't

### Example Connection String, after database removed by code
`Server=myhost.postgres.database.azure.com; User Id=postgres@myhost; Password=Password123!;`

### Error

```
An unhandled exception of type 'Npgsql.PostgresException' occurred in System.Private.CoreLib.dll
3D000: database "postgres@myhost" does not exist
```

### Proposed change
Keep other database providers as-is, but explicitly set Database in connection string to "postgres", after "catalog" has been set.

### Related Side Note
Serene will fail if admin login not created as "postgres" in Azure db setup. This is due to hardcoded ownership in NorthwindDBScript_PostgresData.sql. 
Issue not addressed in this fix, but caused me grief in above testing so noting here