### PR TITLE
Set paceOptions to ignore VS2022 BrowserLink

### DIFF
--- a/Serene/Serene.Web/Views/Shared/_LayoutHead.cshtml
+++ b/Serene/Serene.Web/Views/Shared/_LayoutHead.cshtml
@@ -12,7 +12,7 @@
     @Html.Stylesheet("~/Content/site/site.rtl.css")
 }
 <script type="application/json" id="ScriptCulture">@Html.Raw(Serenity.JSON.Stringify(new ScriptCulture()))</script>
-<script type="text/javascript">window.paceOptions = { startOnPageLoad: false, ajax: { trackMethods: ['GET', 'POST'], trackWebSockets: false, ignoreURLs: [] } };</script>
+<script type="text/javascript">window.paceOptions = { startOnPageLoad: false, ajax: { trackMethods: ['GET', 'POST'], trackWebSockets: false, ignoreURLs: ['browserLinkSignalR'] } };</script>
 @Html.ScriptBundle("Base")
 @Html.ScriptBundle("Site")
 @Html.LocalTextScript("Site")


### PR DESCRIPTION
When developping with VS2022, the progress bar of pace.js is confused by the SignalR calls of the BrowserLink feature. This change gets rid of this.